### PR TITLE
Support link shortener redirects

### DIFF
--- a/lib/re_director.rb
+++ b/lib/re_director.rb
@@ -46,6 +46,11 @@ class ReDirector < Roda
 
     # The rest of the requests
     if opts[:mode] == :independent
+      # Shortener links
+      r.on 'link', String do |link_id|
+        r.redirect "#{opts[:sep]}link/#{link_id}"
+      end
+
       r.is String do
         r.redirect opts[:sep]
       end


### PR DESCRIPTION
This PR adds URL shortener links support (`/link/abc123` redirects to `saberespoder.com/link/abc123` – issue [#2892](https://github.com/saberespoder/inboundsms/issues/2892)